### PR TITLE
Auto populate translation attributes

### DIFF
--- a/src/TranslateableBehavior.php
+++ b/src/TranslateableBehavior.php
@@ -134,7 +134,7 @@ class TranslateableBehavior extends Behavior
         $class = $this->owner->getRelation($this->translationRelation)->modelClass;
 		
 		/* If method create or update - populate attributes */
-		$className = (new \ReflectionClass($this->translationClass))->getShortName();
+		$className = (new \ReflectionClass($class))->getShortName();
 		foreach (Yii::$app->request->post($className, []) as $language => $data) {
             foreach ($data as $attribute => $translation) {
                 $this->owner->translate($language)->$attribute = $translation;


### PR DESCRIPTION
With this changes will automatically populate translation attributes

Now we can use default CRUD controllers actions without any changes:

```
public actionCreate()
{
    $model = new Post();
             if ($model->load(Yii::$app->request->post()) && $model->save()) 
    {
                 return $this->redirect(['view', 
            'id' => $model->id
        ]);
           } else {
                 return $this->render('create', [
                           'model' => $model,
                ]);
           }
}


public function actionUpdate($id)
    {
           $model = $this->findModel($id);
           if ($model->load(Yii::$app->request->post()) && $model->save())
           {
                 return $this->redirect(['view', 
            'id' => $model->id
        ]);
           } else {
                  return $this->render('update', [
                             'model' => $model,
                  ]);
           }
}
```
